### PR TITLE
Conditional HTTPS certificates

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,7 +6,7 @@ import vue from "@vitejs/plugin-vue";
 import fs from "fs";
 import VueI18nPlugin from "@intlify/unplugin-vue-i18n/vite";
 
-const isTesting = process.env.NODE_ENV === 'test'
+const needsCertificate = process.env.NODE_ENV === 'development'
 
 export default defineConfig({
     plugins: [
@@ -22,7 +22,7 @@ export default defineConfig({
         },
     },
     server: {
-        https: isTesting ? undefined : {
+        https: !needsCertificate ? undefined : {
             key: fs.readFileSync('./local-cert/localhost-key.pem'),
             cert: fs.readFileSync('./local-cert/localhost.pem')
         },


### PR DESCRIPTION
De lokale HTTPS certificaten zijn enkel nodig wanneer de development versie uitgevoerd wordt. Door naar de 'NODE_ENV' environment variable te kijken, zal `vite.config.ts` op de productie server niet meer manueel aangepast moeten worden.