### PR TITLE
delete submission fix

### DIFF
--- a/backend/src/submission/models.py
+++ b/backend/src/submission/models.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from sqlalchemy import ForeignKey
-from sqlalchemy.orm import Mapped, mapped_column, relationship, backref
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from datetime import datetime
 import enum
 from src.database import Base

--- a/backend/src/submission/models.py
+++ b/backend/src/submission/models.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from sqlalchemy import ForeignKey
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship, backref
 from datetime import datetime
 import enum
 from src.database import Base
@@ -37,8 +37,11 @@ class Submission(Base):
     stdout: Mapped[str] = mapped_column(nullable=True)
     stderr: Mapped[str] = mapped_column(nullable=True)
 
+    # Without passive_deletes="all", sqlalchemy will for some reason try to set submission_id of TestResult to NULL,
+    # causing a violation error of not_null-constraint.
+    # see https://docs.sqlalchemy.org/en/20/orm/relationship_api.html#sqlalchemy.orm.relationship.params.passive_deletes
     testresults: Mapped[List["TestResult"]] = relationship(
-        back_populates="submission", lazy="joined"
+        back_populates="submission", lazy="joined", passive_deletes="all"
     )
 
 

--- a/backend/src/submission/router.py
+++ b/backend/src/submission/router.py
@@ -15,7 +15,7 @@ from src.submission.dependencies import (
 )
 from src.submission.exceptions import FileNotFound
 from src.submission.exceptions import FilesNotFound
-from src.submission.utils import upload_files
+from src.submission.utils import upload_files, remove_files
 from src.user.dependencies import admin_user_validation, get_authenticated_user
 from src.user.schemas import User
 from . import service
@@ -71,8 +71,9 @@ async def create_submission(background_tasks: BackgroundTasks,
 @router.delete("/{submission_id}",
                dependencies=[Depends(admin_user_validation)],
                status_code=200)
-async def delete_submision(submission_id: int, db: AsyncSession = Depends(get_async_db)):
-    await service.delete_submission(db, submission_id)
+async def delete_submision(submission: Submission = Depends(retrieve_submission), db: AsyncSession = Depends(get_async_db)):
+    remove_files(submission.files_uuid)
+    await service.delete_submission(db, submission.id)
 
 
 @router.get("/{submission_id}/files", response_model=list[File])
@@ -82,7 +83,7 @@ async def get_files(submission: Submission = Depends(retrieve_submission)):
 
 
 @router.get("/{submission_id}/files/{path:path}", response_class=FileResponse)
-async def get_file(path: str, submission: Submission = Depends(get_submission)):
+async def get_file(path: str, submission: Submission = Depends(retrieve_submission)):
     path = submission_path(submission.files_uuid, path)
 
     if not os.path.isfile(path):
@@ -100,7 +101,7 @@ async def get_artifacts(submission: Submission = Depends(retrieve_submission)):
 
 
 @router.get("/{submission_id}/artifacts/{path:path}", response_class=FileResponse)
-async def get_artifact(path: str, submission: Submission = Depends(get_submission)):
+async def get_artifact(path: str, submission: Submission = Depends(retrieve_submission)):
     if submission.status == Status.InProgress:
         raise FileNotFound
 

--- a/backend/src/submission/utils.py
+++ b/backend/src/submission/utils.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 from fastapi import UploadFile
 
-from src.docker_tests.utils import submission_path
+from src.docker_tests.utils import submission_path, submissions_path
 from src.project.schemas import Project
 from src.submission.exceptions import UnMetRequirements
 
@@ -43,3 +43,7 @@ def upload_files(files: list[UploadFile], project: Project) -> str:
         raise UnMetRequirements(errors)
 
     return uuid
+
+
+def remove_files(uuid: str):
+    shutil.rmtree(submissions_path(uuid))

--- a/backend/tests/test_docker.py
+++ b/backend/tests/test_docker.py
@@ -122,7 +122,8 @@ async def test_no_docker_tests(client: AsyncClient, group_id: int, project_id: i
     # cleanup files
     await cleanup_files(submission_id)
 
-    assert not os.path.exists(docker_utils.submissions_path(response.json()["files_uuid"]))
+    assert not os.path.exists(
+        docker_utils.submissions_path(response.json()["files_uuid"]))
     response = await client.get(f"/api/submissions/{submission_id}")
     assert response.status_code == 404
 

--- a/backend/tests/test_docker.py
+++ b/backend/tests/test_docker.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -160,7 +159,7 @@ async def test_default_tests_success(client: AsyncClient, group_id_with_default_
         {'filename': 'artifact.txt', 'media_type': 'text/plain'}]  # generated artifacts
 
     # cleanup files
-    shutil.rmtree(docker_utils.submissions_path(response.json()["files_uuid"]))
+    await cleanup_files(submission_id)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
closes #149 

Vreemde bug waarbij sqlalchemy de foreign key `submission_id` in `testresult` op `null` probeert te zetten wanneer een submisssion wordt verwijderd terwijl dit gewoon zou moeten cascaden.

`passive_deletes="all"` zegt expliciet dat hij dat niet moet doen, en dat alles door de databank zal afgehandeld worden.

Dit probleem doet zich niet voor bij requirements van een project omdat `project_id` daar wel nullable is. Als een project verwijderd wordt, blijven de requirements van dat project gewoon in de databank bestaan met `null` als waarde voor `project_id`. Ik kan dat evt. aanpassen zodat dat zich hetzelfde gedraagt als hier.