### PR TITLE
Fix login error

### DIFF
--- a/backend/src/auth/router.py
+++ b/backend/src/auth/router.py
@@ -59,7 +59,7 @@ async def token(
                 mail=attributes["mail"],
             ),
         )
-    if resolved_user.surname == 'SURNAME_DEFAULT':
+    elif resolved_user.surname == 'SURNAME_DEFAULT':
         resolved_user.surname = attributes["surname"]
 
     # Create JWT token


### PR DESCRIPTION
When a user logs in to the application for the first time, the first login would not work, so a second login was necessary to login