### PR TITLE
Search users with throttle

### DIFF
--- a/frontend/src/components/user/SearchTable.vue
+++ b/frontend/src/components/user/SearchTable.vue
@@ -1,0 +1,125 @@
+<template>
+    <v-data-table-virtual
+        :headers="headers"
+        :items="users"
+        :search="search"
+        :sortBy="sortBy"
+        item-value="uid"
+        :loading="isUserLoading"
+        density="compact"
+        class="table"
+    >
+        <template v-slot:loading>
+            <v-skeleton-loader type="table-row@15" class="table"></v-skeleton-loader>
+        </template>
+        <template v-slot:[`item.is_teacher`]="{ item }">
+            <v-checkbox-btn
+                :model-value="item.is_teacher"
+                @update:model-value="() => onToggleTeacher(item)"
+            ></v-checkbox-btn>
+        </template>
+        <template v-slot:[`item.is_admin`]="{ item }">
+            <v-checkbox-btn
+                :model-value="item.is_admin"
+                :disabled="item.uid === currentUser?.uid"
+                @update:model-value="() => onToggleAdmin(item)"
+            ></v-checkbox-btn>
+        </template>
+        <template v-slot:[`item.actions`]="{ item }">
+            <v-icon v-if="item.uid !== currentUser?.uid" @click="() => onDeleteUser(item)">
+                mdi-delete
+            </v-icon>
+        </template>
+    </v-data-table-virtual>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from "vue";
+import { useI18n } from "vue-i18n";
+import {
+    useCurrentUserQuery,
+    useToggleAdminMutation,
+    useToggleTeacherMutation,
+    useDeleteUserMutation,
+} from "@/queries/User";
+import type User from "@/models/User";
+
+defineProps<{
+    search: string;
+    users: User[];
+}>();
+
+const { t } = useI18n();
+
+const { data: currentUser, isLoading: isUserLoading } = useCurrentUserQuery();
+const { mutateAsync: toggleAdmin } = useToggleAdminMutation();
+const { mutateAsync: toggleTeacher } = useToggleTeacherMutation();
+const { mutateAsync: deleteUser } = useDeleteUserMutation();
+
+/**
+ * Sorts boolean values in descending order.
+ */
+function sortBool(a: boolean, b: boolean): number {
+    return a === b ? 0 : a ? -1 : 1;
+}
+
+const sortBy = ref([{ key: "surname", order: "asc" }]);
+
+async function onToggleAdmin(user: User) {
+    await toggleAdmin(user.uid);
+}
+
+async function onToggleTeacher(user: User) {
+    await toggleTeacher(user.uid);
+}
+
+async function onDeleteUser(user: User) {
+    await deleteUser(user.uid);
+}
+
+const headers = ref([
+    {
+        title: computed(() => t("admin.userTable.surname")),
+        key: "surname",
+        align: "start",
+        sortable: true,
+    },
+    {
+        title: computed(() => t("admin.userTable.name")),
+        key: "given_name",
+        align: "start",
+        sortable: true,
+    },
+    {
+        title: computed(() => t("admin.userTable.uid")),
+        key: "uid",
+        align: "start",
+        sortable: false,
+    },
+    {
+        title: computed(() => t("admin.userTable.email")),
+        key: "mail",
+        align: "start",
+        sortable: false,
+    },
+    {
+        title: computed(() => t("admin.userTable.isTeacher")),
+        key: "is_teacher",
+        sortable: true,
+        filterable: false,
+        filter: () => true, // disable filter
+        sort: sortBool,
+    },
+    {
+        title: computed(() => t("admin.userTable.isAdmin")),
+        key: "is_admin",
+        sortable: true,
+        filterable: false,
+        filter: () => true, // disable filter
+        sort: sortBool,
+    },
+    {
+        key: "actions",
+    },
+]);
+</script>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -95,6 +95,7 @@ export default {
         search: "Search",
         userTable: {
             name: "Name",
+            surname: "Surname",
             uid: "UGent ID",
             email: "Email",
             isTeacher: "Is Teacher",

--- a/frontend/src/i18n/locales/nl.ts
+++ b/frontend/src/i18n/locales/nl.ts
@@ -94,6 +94,7 @@ export default {
         search: "Zoeken",
         userTable: {
             name: "Naam",
+            surname: "Achternaam",
             uid: "UGent ID",
             email: "Email",
             isTeacher: "Is Lesgever",

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -12,3 +12,33 @@ export async function download_file(url: string, filename: string) {
     document.body.appendChild(link);
     link.click();
 }
+
+type ThrottledFunction<T extends (...args: any[]) => any> = (...args: Parameters<T>) => void;
+
+export function throttle<T extends (...args: any[]) => any>(
+    func: T,
+    limit: number
+): ThrottledFunction<T> {
+    let lastFunc: ReturnType<typeof setTimeout>;
+    let lastRan: number;
+
+    return function (this: any, ...args: Parameters<T>) {
+        const context = this;
+
+        if (!lastRan) {
+            func.apply(context, args);
+            lastRan = Date.now();
+        } else {
+            clearTimeout(lastFunc);
+            lastFunc = setTimeout(
+                function () {
+                    if (Date.now() - lastRan >= limit) {
+                        func.apply(context, args);
+                        lastRan = Date.now();
+                    }
+                },
+                limit - (Date.now() - lastRan)
+            );
+        }
+    };
+}

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -3,129 +3,40 @@
         <v-card :title="$t('admin.users')" flat>
             <v-card-title>
                 <v-text-field
+                    :loading="searchLoading"
                     prepend-inner-icon="mdi-magnify"
-                    v-model="search"
                     :label="$t('admin.search')"
                     single-line
                     hide-details
+                    @update:model-value="onSearch"
                 ></v-text-field>
             </v-card-title>
-            <v-data-table-virtual
-                :headers="headers"
-                :items="users"
-                :search="search"
-                v-model:sortBy="sortBy"
-                item-value="uid"
-                :loading="isUserLoading || isUsersLoading"
-                density="compact"
-                class="table"
-            >
-                <template v-slot:loading>
-                    <v-skeleton-loader type="table-row@15" class="table"></v-skeleton-loader>
-                </template>
-                <template v-slot:[`item.is_teacher`]="{ item }">
-                    <v-checkbox-btn
-                        :model-value="item.is_teacher"
-                        @update:model-value="() => onToggleTeacher(item)"
-                    ></v-checkbox-btn>
-                </template>
-                <template v-slot:[`item.is_admin`]="{ item }">
-                    <v-checkbox-btn
-                        :model-value="item.is_admin"
-                        :disabled="item.uid === currentUser?.uid"
-                        @update:model-value="() => onToggleAdmin(item)"
-                    ></v-checkbox-btn>
-                </template>
-                <template v-slot:[`item.actions`]="{ item }">
-                    <v-icon v-if="item.uid !== currentUser?.uid" @click="() => onDeleteUser(item)">
-                        mdi-delete
-                    </v-icon>
-                </template>
-            </v-data-table-virtual>
+            <SearchTable :search="search" :users="users || []" />
         </v-card>
     </div>
 </template>
 <script setup lang="ts">
-import { ref, computed } from "vue";
-import { useI18n } from "vue-i18n";
-import {
-    useCurrentUserQuery,
-    useUsersQuery,
-    useToggleAdminMutation,
-    useToggleTeacherMutation,
-    useDeleteUserMutation,
-} from "@/queries/User";
-import type User from "@/models/User";
-
-const { t } = useI18n();
-
-const { data: currentUser, isLoading: isUserLoading } = useCurrentUserQuery();
-const { data: users, isLoading: isUsersLoading } = useUsersQuery();
-const { mutateAsync: toggleAdmin } = useToggleAdminMutation();
-const { mutateAsync: toggleTeacher } = useToggleTeacherMutation();
-const { mutateAsync: deleteUser } = useDeleteUserMutation();
-
-/**
- * Sorts boolean values in descending order.
- */
-function sortBool(a: boolean, b: boolean): number {
-    return a === b ? 0 : a ? -1 : 1;
-}
+import SearchTable from "@/components/user/SearchTable.vue";
+import { useUsersQuery } from "@/queries/User";
+import { throttle } from "@/utils";
+import { ref } from "vue";
 
 const search = ref("");
-const sortBy = ref([{ key: "given_name", order: "asc" }]);
+const searchLoading = ref(false);
 
-async function onToggleAdmin(user: User) {
-    await toggleAdmin(user.uid);
+const { data: users } = useUsersQuery();
+
+function setSearch(value: string) {
+    search.value = value;
+    searchLoading.value = false;
 }
 
-async function onToggleTeacher(user: User) {
-    await toggleTeacher(user.uid);
-}
+const throttledSetSearch = throttle(setSearch, 500);
 
-async function onDeleteUser(user: User) {
-    await deleteUser(user.uid);
+function onSearch(value: string) {
+    searchLoading.value = true;
+    throttledSetSearch(value);
 }
-
-const headers = ref([
-    {
-        title: computed(() => t("admin.userTable.name")),
-        key: "given_name",
-        align: "start",
-        sortable: true,
-    },
-    {
-        title: computed(() => t("admin.userTable.uid")),
-        key: "uid",
-        align: "start",
-        sortable: false,
-    },
-    {
-        title: computed(() => t("admin.userTable.email")),
-        key: "mail",
-        align: "start",
-        sortable: false,
-    },
-    {
-        title: computed(() => t("admin.userTable.isTeacher")),
-        key: "is_teacher",
-        sortable: true,
-        filterable: false,
-        filter: () => true, // disable filter
-        sort: sortBool,
-    },
-    {
-        title: computed(() => t("admin.userTable.isAdmin")),
-        key: "is_admin",
-        sortable: true,
-        filterable: false,
-        filter: () => true, // disable filter
-        sort: sortBool,
-    },
-    {
-        key: "actions",
-    },
-]);
 </script>
 <style scoped>
 .adminpanel {

--- a/frontend/tests/components/user/SearchTable.spec.ts
+++ b/frontend/tests/components/user/SearchTable.spec.ts
@@ -1,0 +1,21 @@
+import { mount } from "@vue/test-utils";
+import {expect, describe, it, vi} from "vitest";
+import SearchTable from "@/components/user/SearchTable.vue"
+
+describe("SearchTable", async () => {
+    const ResizeObserverMock = vi.fn(() => ({
+        observe: vi.fn(),
+        unobserve: vi.fn(),
+        disconnect: vi.fn(),
+    }));
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    const wrapper = mount(SearchTable, {});
+    it("sorts booleans true first", () => {
+        const instance = wrapper.vm;
+        const sortBoolFunction = (instance as any).sortBool;
+        expect(sortBoolFunction(true, true)).toBe(0)
+        expect(sortBoolFunction(false, false)).toBe(0)
+        expect(sortBoolFunction(false, true)).toBe(1)
+        expect(sortBoolFunction(true, false)).toBe(-1)
+    })
+});

--- a/frontend/tests/utils.spec.ts
+++ b/frontend/tests/utils.spec.ts
@@ -1,0 +1,48 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {throttle} from "@/utils";
+
+describe('throttle', () => {
+    beforeEach(() => {
+       vi.useFakeTimers();
+    });
+    afterEach(() => {
+        vi.clearAllTimers();
+    });
+
+    it("should call a function immediately", () => {
+        const func = vi.fn();
+        const throttledFunc = throttle(func, 1000);
+        throttledFunc();
+        expect(func).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call a function only once within the time limit", () => {
+        const func = vi.fn();
+        const throttledFunc = throttle(func, 1000);
+        throttledFunc();
+        throttledFunc();
+        throttledFunc();
+        expect(func).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call the function again after the time limit", () => {
+        const func = vi.fn();
+        const throttledFunc = throttle(func, 1000);
+        throttledFunc();
+        throttledFunc();
+        expect(func).toHaveBeenCalledTimes(1);
+        vi.advanceTimersByTime(1500);
+        expect(func).toHaveBeenCalledTimes(2);
+    });
+
+    it("should omit subsequent calls within the time limit", () => {
+        const func = vi.fn();
+        const throttledFunc = throttle(func, 1000);
+        throttledFunc();
+        throttledFunc();
+        throttledFunc();
+        throttledFunc();
+        vi.advanceTimersByTime(2000);
+        expect(func).toHaveBeenCalledTimes(2);
+    });
+});

--- a/frontend/tests/utils.spec.ts
+++ b/frontend/tests/utils.spec.ts
@@ -42,7 +42,7 @@ describe('throttle', () => {
         throttledFunc();
         throttledFunc();
         throttledFunc();
-        vi.advanceTimersByTime(2000);
+        vi.advanceTimersByTime(10000);
         expect(func).toHaveBeenCalledTimes(2);
     });
 });

--- a/frontend/tests/views/AdminView.spec.ts
+++ b/frontend/tests/views/AdminView.spec.ts
@@ -48,14 +48,4 @@ describe("AdminView", async () => {
         expect(VDataTableVirtual.text()).toContain("Is Lesgever")
         expect(VDataTableVirtual.text()).toContain("Is Beheerder")
     });
-
-    it("test sort bool function", () => {
-        const instance = wrapper.vm;
-        const sortBoolFunction = (instance as any).sortBool;
-        expect(sortBoolFunction(true, true)).toBe(0)
-        expect(sortBoolFunction(false, false)).toBe(0)
-        expect(sortBoolFunction(false, true)).toBe(1)
-        expect(sortBoolFunction(true, false)).toBe(-1)
-    });
-
 });


### PR DESCRIPTION
Wanneer er heel veel gebruikers zijn, zal het filteren op zoektermen een dure operatie worden. Met throttling wordt er voor gezorgd dat dit maximaal 1 keer in een bepaald tijdsinterval zal gebeuren.