### PR TITLE
fix #246 tests: docker 7.0.0 -> 7.1.0

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,7 +11,7 @@ cffi==1.16.0
 charset-normalizer==3.3.2
 click==8.1.7
 cryptography==42.0.5
-docker==7.0.0
+docker==7.1.0
 exceptiongroup==1.1.2
 fastapi==0.109.2
 greenlet==3.0.3


### PR DESCRIPTION
Compatibiliteit met requests `2.32.0`, zie https://github.com/docker/docker-py/pull/3257.

Fixt #246.